### PR TITLE
Reusable test suite for payment gateways

### DIFF
--- a/src/Codeception/Module/WooCommerceDB.php
+++ b/src/Codeception/Module/WooCommerceDB.php
@@ -28,6 +28,23 @@ class WooCommerceDB extends WPDb {
 
 
 	/**
+	 * Updates the settings for the specified payment gateway.
+	 *
+	 * TODO: move to a trait with PaymentGateway or PaymentGateway\Settings related methods.
+	 *
+	 * @param string $gateway_id the ID of the payment gateway
+	 * @param array $settings the new settings
+	 */
+	public function havePaymentGatewaySettingsInDatabase( string $gateway_id, array $settings ) {
+
+		$setting_name     = sprintf( 'woocommerce_%s_settings', $gateway_id );
+		$current_settings = get_option( $setting_name, [] );
+
+		update_option( $setting_name, array_merge( $current_settings, $settings ) );
+	}
+
+
+	/**
 	 * Creates a simple product in the database.
 	 *
 	 * @param array $props product properties

--- a/src/Page/Frontend/Checkout.php
+++ b/src/Page/Frontend/Checkout.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SkyVerge\Lumiere\Page\Frontend;
+
+use Codeception\Actor;
+use Codeception\Module\WPWebDriver;
+
+/**
+ * Checkout page object.
+ */
+class Checkout {
+
+
+	/** @var string default URL for the Checkout page */
+	const URL = '/checkout';
+
+	/** @var string selector for the Billing First Name field */
+	const FIELD_BILLING_FIRST_NAME = '[name="billing_first_name"]';
+
+	/** @var string selector for the Billing Last Name field */
+	const FIELD_BILLING_LAST_NAME = '[name="billing_last_name"]';
+
+	/** @var string selector for the Billing Address field */
+	const FIELD_BILLING_ADDRESS_1 = '[name="billing_address_1"]';
+
+	/** @var string selector for the Billing City field */
+	const FIELD_BILLING_CITY = '[name="billing_city"]';
+
+	/** @var string selector for the Billing Postcode field */
+	const FIELD_BILLING_POSTCODE = '[name="billing_postcode"]';
+
+	/** @var string selector for the Billing Phone field */
+	const FIELD_BILLING_PHONE = '[name="billing_phone"]';
+
+	/** @var string selector for the Billing Email field */
+	const FIELD_BILLING_EMAIL = '[name="billing_email"]';
+
+	/** @var string selector for the Place Order button */
+	const BUTTON_PLACE_ORDER = '[name="woocommerce_checkout_place_order"]';
+
+
+    /** @var WPWebDriver|Actor our tester */
+	protected $tester;
+
+
+	/**
+	 * Constructor for Checkout page object.
+	 *
+	 * @param WPWebDriver|Actor $I tester instance
+	 */
+    public function __construct( \FrontendTester $I ) {
+
+        $this->tester = $I;
+	}
+
+
+    /**
+	 * Returns the URL to the Checkout page.
+	 *
+	 * @return string
+     */
+    public static function route() {
+
+        return self::URL;
+	}
+
+
+	/**
+	 * Fills the billing fields with default values.
+	 */
+	public function fillBillingDetails() {
+
+		$this->tester->fillField( self::FIELD_BILLING_FIRST_NAME, 'John' );
+		$this->tester->fillField( self::FIELD_BILLING_LAST_NAME,  'Doe' );
+		$this->tester->fillField( self::FIELD_BILLING_ADDRESS_1,  'Ste 2B' );
+		$this->tester->fillField( self::FIELD_BILLING_CITY,       'Boston' );
+		$this->tester->fillField( self::FIELD_BILLING_POSTCODE,   '02115' );
+		$this->tester->fillField( self::FIELD_BILLING_PHONE,      '800-970-1259' );
+		$this->tester->fillField( self::FIELD_BILLING_EMAIL,      'john@example.com' );
+	}
+
+
+	/**
+	 * Checks that the label of the payment method matches the provided title.
+	 *
+	 * @param string $gateway_id the ID of the gateway
+	 * @param string $title the expected title
+	 */
+	public function seePaymentMethodTitle( string $gateway_id, string $title ) {
+
+		$label_selector = sprintf( 'label[for="payment_method_%s"]' , $gateway_id );
+
+		$this->tester->waitForElementClickable( $label_selector );
+		$this->tester->see( $title, $label_selector );
+	}
+
+
+}

--- a/src/Page/Frontend/Product.php
+++ b/src/Page/Frontend/Product.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SkyVerge\Lumiere\Page\Frontend;
+
+use Codeception\Actor;
+use Codeception\Module\WPWebDriver;
+
+/**
+ * Product page object.
+ */
+class Product {
+
+
+    /** @var WPWebDriver|Actor our tester */
+	protected $tester;
+
+
+    /**
+     * Returns the URL to a product page.
+	 *
+	 * @param \WC_Product $product the product
+	 *
+	 * @return string
+     */
+    public static function route( \WC_Product $product )  {
+
+		return str_replace( home_url(), '', $product->get_permalink() );
+    }
+
+
+	/**
+	 * Constructor for the Product page object.
+	 *
+	 * @param WPWebDriver|Actor $I tester instance
+	 */
+	public function __construct( \FrontendTester $I ) {
+
+		$this->tester = $I;
+	}
+
+
+	/**
+	 * Adds a product to the cart from the product page.
+	 *
+	 * @param \WC_Product $product the product
+	 * @return int
+	 */
+	public function addSimpleProductToCart( \WC_Product $product ) {
+
+		// am I on product page?
+		$this->tester->see( $product->get_name() );
+
+		// add product to cart (but don't visit cart page yet)
+		$this->tester->click( sprintf( '//button[@name="add-to-cart" and @value=%d]', $product->get_id() ) );
+
+		return $product->get_id();
+	}
+
+
+}

--- a/src/Tests/Frontend/PaymentGateways/CreditCardCest.php
+++ b/src/Tests/Frontend/PaymentGateways/CreditCardCest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SkyVerge\Lumiere\Tests\Frontend\PaymentGateways;
+
+use Codeception\Actor;
+use Codeception\Module\WPWebDriver;
+use SkyVerge\Lumiere\Page\Frontend\Product;
+use SkyVerge\Lumiere\Page\Frontend\Checkout;
+use SkyVerge\Lumiere\Tests\AcceptanceBase;
+
+abstract class CreditCardCest extends AcceptanceBase {
+
+
+	/** @var \WC_Product_Simple a shippable product */
+	protected $shippable_product;
+
+
+	/**
+	 * Runs before each test.
+	 *
+	 * @param WPWebDriver|Actor $I tester instance
+	 */
+	public function _before( $I ) {
+
+		parent::_before( $I );
+
+		// TODO: consider creating these products as a run-once-per-suite action or using WP-CLI in wp-bootstrap.php {WV 2020-03-29}
+		$this->shippable_product = $this->tester->haveSimpleProductInDatabase( [ 'name' => 'Shippable 1' ] );
+	}
+
+
+    public function try_custom_name_is_shown( Product $single_product_page, Checkout $checkout_page ) {
+
+		$this->tester->havePaymentGatewaySettingsInDatabase( $this->get_payment_gateway_id(), [ 'title' => 'My Credit Card' ] );
+
+		$this->tester->amOnPage( Product::route( $this->shippable_product ) );
+
+		$single_product_page->addSimpleProductToCart( $this->shippable_product );
+
+		$this->tester->amOnPage( Checkout::route() );
+
+		$checkout_page->seePaymentMethodTitle( $this->get_payment_gateway_id(), 'My Credit Card' );
+	}
+
+
+	public function try_successful_transaction_for_shippable_product( Product $single_product_page, Checkout $checkout_page ) {
+
+		$this->tester->amOnPage( Product::route( $this->shippable_product ) );
+
+		$single_product_page->addSimpleProductToCart( $this->shippable_product );
+
+		$this->tester->amOnPage( Checkout::route() );
+
+		$checkout_page->fillBillingDetails();
+
+		$this->place_order( $checkout_page );
+
+		$this->tester->waitForElementVisible( '.woocommerce-order-details' );
+		$this->tester->see( 'Order received', '.entry-title' );
+	}
+
+
+	/**
+	 * Gets the ID of the payment gateway being tested.
+	 *
+	 * @return string
+	 */
+	protected abstract function get_payment_gateway_id();
+
+
+	/**
+	 * Performs the necessary steps to place a new order from the Checkout page.
+	 *
+	 * Normally clicking the Place Order button is the only necessary step.
+	 * Payment geteways may overwrite this method to perform extra steps, like entering a particular credit card number or test amount.
+	 *
+	 * @param Checkout $checkout_page Checkout page object
+	 */
+	protected function place_order( Checkout $checkout_page ) {
+
+		$this->tester->click( Checkout::BUTTON_PLACE_ORDER );
+	}
+
+
+}


### PR DESCRIPTION
## Summary

This PR includes a POC and proposal on how we could start building a reusable test suite for payment gateways.

The purpose of the PR is to give an example of the concepts described in the [Discovery: Reusable test suite for payment gateways](https://docs.google.com/document/d/1tkqqARp2iENA8MKw3HktThpRNN1zHpskgyU5WnqWUMM/edit#) document.

## QA

I branched of the `docker-compose` branch to facilitate testing. There is a PR for adding a docker-compose environment to Lumiere at https://github.com/ChaseWiseman/lumiere/pull/2

To try the `CreditCardCest` class on Authorize.Net, you need to setup this branch of Lumiere as described in the [QA > Setup section of the docker-compose PR](https://github.com/ChaseWiseman/lumiere/pull/2). Don't follow the instructions in the Steps section yet.

Once Lumiere is setup:

1. Update `.env.lumiere` to define values for the `TEST_API_LOGIN_ID`, `TEST_API_TRANSACTION_KEY`, and `TEST_API_SIGNATURE_KEY` environment variables (use the values from the wiki)
1. Add a `wp-bootstrap.sh` file to the `wc-plugins/woocommerce-gateway-authorize-net-cim` directory to add Authorize.Net specific configuration to the WordPress installation

    ```bash
	source .env.lumiere

	cd /wordpress

	wp wc payment_gateway update authorize_net_cim_credit_card --enabled=true --user=admin

	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings debug_mode "log"
	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings transaction_type "authorization"
	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings charge_virtual_orders "yes"
	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings enable_paid_capture "yes"
	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings tokenization "yes"
	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings environment "test"
	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings test_api_login_id "$TEST_API_LOGIN_ID"
	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings test_api_transaction_key "$TEST_API_TRANSACTION_KEY"
	wp option patch insert woocommerce_authorize_net_cim_credit_card_settings test_api_signature_key "$TEST_API_SIGNATURE_KEY"
    ```
1. Add `tests/frontend/CreditCardCest.php` with the following content:

    ```php
    <?php

    use SkyVerge\Lumiere\Page\Frontend\Checkout;

    class CreditCardCest extends SkyVerge\Lumiere\Tests\Frontend\PaymentGateways\CreditCardCest {


        /**
         * Performs the necessary steps to place a new order from the Checkout page.
         *
         * @see SkyVerge\Lumiere\Tests\Frontend\PaymentGateways\CreditCardCest::place_order()
         *
         * @param Checkout $checkout_page Checkout page object
         */
        protected function place_order( Checkout $checkout_page ) {

            $this->tester->fillField( '#wc-authorize-net-cim-credit-card-account-number', '4012888818888' );

            $this->tester->click( Checkout::BUTTON_PLACE_ORDER );
        }


        /**
         * Gets the plugin instance.
         *
         * @return object
         */
        protected function get_plugin() {

            return wc_authorize_net_cim();
        }


        /**
         * Gets the ID of the payment gateway being tested.
         *
         * @return string
         */
        protected function get_payment_gateway_id() {

            return 'authorize_net_cim_credit_card';
        }


    }
    ```
3. Follow the instructions in the Steps section to create the containers and run the `frontend` test suite.

If you run the tests, two scenarios are tested, but the concrete implementation is limited to defining a method that returns an instance of the plugin, a method that returns the ID of the gateway being tested, and add a custom implementation of the method that clicks the Place Order button in the Checkout page.

All the other steps necessary to perform the tests are defined in the abstract Cest and inherited.
