### PR TITLE
Add configuration files for a docker-compose environment to run tests

### DIFF
--- a/configs/admin.suite.yml
+++ b/configs/admin.suite.yml
@@ -30,7 +30,7 @@ modules:
       adminPassword: '%WP_ADMIN_PASSWORD%'
       adminPath: '%WP_ADMIN_PATH%'
       browser: 'chrome'
-      host: '%SELENIUM_HOST'
+      host: '%SELENIUM_HOST%'
       capabilities:
         acceptInsecureCerts: true
         enableVerboseLogging: true

--- a/configs/admin.suite.yml
+++ b/configs/admin.suite.yml
@@ -30,6 +30,7 @@ modules:
       adminPassword: '%WP_ADMIN_PASSWORD%'
       adminPath: '%WP_ADMIN_PATH%'
       browser: 'chrome'
+      host: '%SELENIUM_HOST'
       capabilities:
         acceptInsecureCerts: true
         enableVerboseLogging: true

--- a/configs/frontend.suite.yml
+++ b/configs/frontend.suite.yml
@@ -30,7 +30,7 @@ modules:
       adminPassword: '%WP_ADMIN_PASSWORD%'
       adminPath: '%WP_ADMIN_PATH%'
       browser: 'chrome'
-      host: '%SELENIUM_HOST'
+      host: '%SELENIUM_HOST%'
       capabilities:
         acceptInsecureCerts: true
         enableVerboseLogging: true

--- a/configs/frontend.suite.yml
+++ b/configs/frontend.suite.yml
@@ -30,6 +30,7 @@ modules:
       adminPassword: '%WP_ADMIN_PASSWORD%'
       adminPath: '%WP_ADMIN_PATH%'
       browser: 'chrome'
+      host: '%SELENIUM_HOST'
       capabilities:
         acceptInsecureCerts: true
         enableVerboseLogging: true

--- a/docker/codeception/Dockerfile
+++ b/docker/codeception/Dockerfile
@@ -1,0 +1,61 @@
+FROM php:7.4-cli-buster
+
+# Install required system packages
+RUN apt-get update && \
+    apt-get -y install \
+            git \
+            zlib1g-dev \
+            libssl-dev \
+            libfreetype6-dev \
+            libjpeg62-turbo-dev \
+            libpng-dev \
+			libzip-dev \
+            default-mysql-client \
+            sudo less \
+            zip unzip \
+        --no-install-recommends && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install php extensions
+RUN docker-php-ext-install \
+    bcmath \
+    gd \
+    zip
+
+RUN docker-php-ext-install -j$(nproc) iconv \
+        && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
+        && docker-php-ext-install -j$(nproc) gd
+
+# Add mysql driver required for wp-browser
+RUN docker-php-ext-install mysqli pdo_mysql
+
+# Configure php
+RUN echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini
+
+# Install composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN curl -sS https://getcomposer.org/installer | php -- \
+        --filename=composer \
+        --install-dir=/usr/local/bin
+RUN composer global require --optimize-autoloader \
+        "hirak/prestissimo"
+
+# Add WP-CLI
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+RUN chmod +x wp-cli.phar
+RUN mv wp-cli.phar /usr/local/bin
+
+# Allows WP CLI to run with the right permissions.
+RUN echo "#\!/bin/bash\nsudo -E -u www-data /usr/local/bin/wp-cli.phar \"\$@\"" > /usr/local/bin/wp
+RUN chmod +x /usr/local/bin/wp
+
+ADD docker-entrypoint.sh /usr/local/bin/
+
+RUN ["chmod", "+x", "/usr/local/bin/docker-entrypoint.sh"]
+
+WORKDIR /project
+
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+
+CMD ["start"]

--- a/docker/codeception/docker-entrypoint.sh
+++ b/docker/codeception/docker-entrypoint.sh
@@ -103,7 +103,9 @@ PHP
 	# install vendor
 	composer install --prefer-dist
 
-	# allow each plugin to configure the wordpress instance
+	wp plugin activate $PLUGIN_DIR --path=/wordpress
+
+	# allow each plugin to configure the WordPress instance
 	if [ -f wp-bootstrap.sh ]; then
 		source wp-bootstrap.sh
 	fi

--- a/docker/codeception/docker-entrypoint.sh
+++ b/docker/codeception/docker-entrypoint.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+wp_bootstrap() {
+
+	WP_URL=wp.test
+	WP_ADMIN_USERNAME=admin
+	WP_ADMIN_PASSWORD=password
+	WP_ADMIN_EMAIL="admin@$WP_URL"
+	DB_HOST=mysql
+	DB_NAME=acceptance_tests
+	DB_USER=root
+	DB_PASSWORD=root
+	TABLE_PREFIX=wp_
+
+	echo "Preparing WordPress"
+
+	cd /wordpress
+
+	echo "Making sure permissions are correct"
+
+	# make sure permissions are correct (maybe can be avoided with https://stackoverflow.com/a/56990338).
+	chown www-data:www-data /wordpress /wordpress/wp-content /wordpress/wp-content/plugins
+	chmod 755 /wordpress /wordpress /wordpress/wp-content /wordpress/wp-content/plugins
+
+	echo "Making sure the database server is up and running"
+
+	while ! mysqladmin ping -h$DB_HOST --silent; do
+
+		echo "Waiting for the database server (host: $DB_HOST)"
+		sleep 1
+	done
+
+	echo 'The database server is ready'
+
+	echo "Creating acceptance_tests database if it doesn't exist"
+	mysql -h$DB_HOST -u$DB_USER -p$DB_PASSWORD -e "CREATE DATABASE IF NOT EXISTS acceptance_tests"
+
+	echo "Creating integration_tests database if it doesn't exist"
+	mysql -h$DB_HOST -u$DB_USER -p$DB_PASSWORD -e "CREATE DATABASE IF NOT EXISTS integration_tests"
+
+	if [ ! -f wp-config.php ]; then
+
+		echo "Creating wp-config.php"
+
+		# we can't use wp core commands if the wp-config.php file is not present
+		wp config create --dbhost=$DB_HOST --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASSWORD
+	fi
+
+	# Make sure WordPress is installed.
+	if ! $(wp core is-installed); then
+
+		echo "Installing WordPress"
+
+		wp core install --url=$WP_URL --title=tests --admin_user=$WP_ADMIN_USERNAME --admin_password=$WP_ADMIN_PASSWORD --admin_email=$WP_ADMIN_EMAIL
+
+		# overwrite existing configuration to make sure we are using the correct values
+		wp core config --dbhost=$DB_HOST --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASSWORD --dbprefix=$TABLE_PREFIX --force --extra-php <<'PHP'
+// allows URLs to work while accessing the WordPress service from the host using mapped ports
+if ( 8443 === (int) $_SERVER['SERVER_PORT'] || 8080 === (int) $_SERVER['SERVER_PORT'] ) {
+	$protocol = 8443 === (int) $_SERVER['SERVER_PORT'] ? 'https' : 'http';
+	define( 'WP_HOME', "{$protocol}://{$_SERVER['HTTP_HOST']}" );
+	define( 'WP_SITEURL', "{$protocol}://{$_SERVER['HTTP_HOST']}" );
+}
+PHP
+	fi
+
+	wp core update-db
+	wp rewrite structure '/%postname%/' --hard
+
+	wp db export fresh-install.sql
+
+
+	echo "Installing and configuring WooCommerce"
+
+	wp plugin install woocommerce --activate
+
+	wp option update woocommerce_store_address "177 Huntington Ave Ste 1700"
+	wp option update woocommerce_store_address_2 "70640"
+	wp option update woocommerce_store_city "Boston"
+	wp option update woocommerce_store_postcode "02115-3153"
+	wp option update woocommerce_default_country "US:MA"
+	wp option update woocommerce_currency "USD"
+
+	# remove WooCommerce admin notices
+	wp option update woocommerce_admin_notices [] --format=json
+
+	wp wc tool run db_update_routine --user=admin
+	wp wc tool run install_pages --user=admin
+
+	# prevent WooCommerce redirection to Setup Wizard
+	wp transient delete _wc_activation_redirect
+
+	# run action-scheduler to make sure all necessary tables are created
+	wp action-scheduler run
+
+	wp theme install --activate storefront
+
+
+	echo "Preparing plugin"
+
+	cd /project
+
+	# install vendor
+	composer install --prefer-dist
+
+	# allow each plugin to configure the wordpress instance
+	if [ -f wp-bootstrap.sh ]; then
+		source wp-bootstrap.sh
+	fi
+
+
+	echo "Generating tests/_data/dump.sql"
+
+	cd /wordpress
+
+	mkdir -p /project/tests/_data
+
+	wp db export /project/tests/_data/dump.sql
+
+
+	echo "Importing tests/_data/dump.sql into the integration_tests database"
+
+	mysql -h$DB_HOST -u$DB_USER -p$DB_PASSWORD integration_tests -e 'source /project/tests/_data/dump.sql'
+
+
+	echo "WordPress is ready"
+}
+
+
+if [[ "$1" == bootstrap ]]; then
+
+	wp_bootstrap
+
+elif [[ "$1" == start ]]; then
+
+	wp_bootstrap
+
+	# keep the service running...
+	exec tail -f /dev/null
+
+else
+
+	# allow one-off command execution
+	exec "$@"
+
+fi

--- a/docker/codeception/docker-entrypoint.sh
+++ b/docker/codeception/docker-entrypoint.sh
@@ -109,7 +109,7 @@ PHP
 	fi
 
 
-	echo "Generating tests/_data/dump.sql"
+	echo "Exporting acceptance_tests database into tests/_data/dump.sql"
 
 	cd /wordpress
 
@@ -118,9 +118,9 @@ PHP
 	wp db export /project/tests/_data/dump.sql
 
 
-	echo "Importing tests/_data/dump.sql into the integration_tests database"
+	echo "Importing tests/_data/dump.sql into integration_tests database"
 
-	mysql -h$DB_HOST -u$DB_USER -p$DB_PASSWORD integration_tests -e 'source /project/tests/_data/dump.sql'
+	wp db import --dbuser=$DB_USER --dbpass=$DB_PASSWORD --host=$DB_HOST --database=integration_tests /project/tests/_data/dump.sql
 
 
 	echo "WordPress is ready"

--- a/docker/codeception/docker-entrypoint.sh
+++ b/docker/codeception/docker-entrypoint.sh
@@ -2,10 +2,11 @@
 
 wp_bootstrap() {
 
-	WP_URL=wp.test
+	WP_DOMAIN=wp.test
+	WP_URL="https://$WP_DOMAIN"
 	WP_ADMIN_USERNAME=admin
 	WP_ADMIN_PASSWORD=password
-	WP_ADMIN_EMAIL="admin@$WP_URL"
+	WP_ADMIN_EMAIL="admin@$WP_DOMAIN"
 	DB_HOST=mysql
 	DB_NAME=acceptance_tests
 	DB_USER=root

--- a/docker/codeception/docker-entrypoint.sh
+++ b/docker/codeception/docker-entrypoint.sh
@@ -65,7 +65,9 @@ if ( 8443 === (int) $_SERVER['SERVER_PORT'] || 8080 === (int) $_SERVER['SERVER_P
 PHP
 	fi
 
+	wp core update
 	wp core update-db
+
 	wp rewrite structure '/%postname%/' --hard
 
 	wp db export fresh-install.sql

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '2'
+
+services:
+  codeception:
+    build: codeception
+    depends_on:
+      - wordpress
+    environment:
+      - WP_CLI_CACHE_DIR=/wordpress/.wp-cli/cache
+    volumes:
+      - wordpress:/wordpress
+
+  wordpress:
+    build: wordpress
+    depends_on:
+      - mysql
+      - chrome
+    hostname: wp.test
+    networks:
+      default:
+        aliases:
+          - wp.test
+    volumes:
+      - wordpress:/var/www/html
+    ports:
+      - "8080:80"
+      - "8443:443"
+
+  mysql:
+    image: mariadb
+    environment:
+       MYSQL_ROOT_PASSWORD: root
+
+  chrome:
+    image: selenium/standalone-chrome-debug:3.141.59-dubnium
+    environment:
+      - DBUS_SESSION_BUS_ADDRESS=/dev/null
+    volumes:
+      - /dev/shm:/dev/shm
+    ports:
+      - "4444:4444"
+      - "5900:5900"
+
+volumes:
+  wordpress:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - wordpress
     environment:
       - WP_CLI_CACHE_DIR=/wordpress/.wp-cli/cache
+      - PLUGIN_DIR=$PLUGIN_DIR
     volumes:
       - wordpress:/wordpress
 

--- a/docker/wordpress/Dockerfile
+++ b/docker/wordpress/Dockerfile
@@ -1,0 +1,9 @@
+FROM wordpress:latest
+
+ADD apache2-foreground-with-ssl /usr/local/bin/
+
+RUN ["chmod", "+x", "/usr/local/bin/apache2-foreground-with-ssl"]
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["apache2-foreground-with-ssl"]

--- a/docker/wordpress/apache2-foreground-with-ssl
+++ b/docker/wordpress/apache2-foreground-with-ssl
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -f /etc/ssl/localcerts/apache.pem ]; then
+
+	mkdir -p /etc/ssl/localcerts
+	openssl req -new -x509 -days 365 -nodes -out /etc/ssl/localcerts/apache.pem -keyout /etc/ssl/localcerts/apache.key -subj "/C=US"
+	chmod 600 /etc/ssl/localcerts/apache*
+
+	a2enmod ssl
+
+	sed -e 's/certs\/ssl-cert-snakeoil.pem/localcerts\/apache.pem/' -ibak /etc/apache2/sites-available/default-ssl.conf
+	sed -e 's/private\/ssl-cert-snakeoil.key/localcerts\/apache.key/' -ibak /etc/apache2/sites-available/default-ssl.conf
+
+	a2ensite default-ssl
+fi
+
+exec apache2-foreground

--- a/src/Codeception/Template/Lumiere.php
+++ b/src/Codeception/Template/Lumiere.php
@@ -144,6 +144,11 @@ class Lumiere extends Wpbrowser {
 			'wp_'
 		);
 
+		$installation_data['SELENIUM_HOST'] = $this->ask(
+			'What is the host of the Selenium server you\'ll use for acceptance tests?',
+			'localhost'
+		);
+
 		$installation_data['INTEGRATION_DB_NAME'] = $this->ask(
 			'What is the name of the database you\'ll use for integration tests?',
 			'integration_tests'

--- a/src/Codeception/Template/Lumiere.php
+++ b/src/Codeception/Template/Lumiere.php
@@ -249,8 +249,10 @@ class Lumiere extends Wpbrowser {
 				$value = $value ? 'true' : 'false';
 			} elseif ( null === $value ) {
 				$value = 'null';
-			} elseif ( \is_string( $value ) ) {
+			} elseif ( \is_string( $value ) && strpos( trim( $value ), ' ' ) ) {
 				$value = '"' . trim( $value ) . '"';
+			} elseif ( \is_string( $value ) ) {
+				$value = trim( $value );
 			} else {
 				continue;
 			}

--- a/src/Codeception/Template/Lumiere.php
+++ b/src/Codeception/Template/Lumiere.php
@@ -249,7 +249,7 @@ class Lumiere extends Wpbrowser {
 				$value = $value ? 'true' : 'false';
 			} elseif ( null === $value ) {
 				$value = 'null';
-			} elseif ( \is_string( $value ) && strpos( trim( $value ), ' ' ) ) {
+			} elseif ( \is_string( $value ) && \strpos( trim( $value ), ' ' ) ) {
 				$value = '"' . trim( $value ) . '"';
 			} elseif ( \is_string( $value ) ) {
 				$value = trim( $value );


### PR DESCRIPTION
## Summary

This PR adds the Docker Compose configuration files to run Lumiere's test suites on docker containers, removing the need to configure a local WordPress installation or commit a SQL dump file.

## QA (and details)

Try the following steps on a plugin that doesn't currently have a test suite. I tested with Authorize.Net.

### Setup

- Install [Docker](https://www.docker.com/get-started)
- Install Lumiere via composer (from [wvega/lumiere](https://github.com/wvega/lumiere)):

    Add a new entry in `repositories`:
    ```
    {
      "type": "vcs",
      "url": "git@github.com:wvega/lumiere.git"
    }
    ```

    Add a new entry to `require-dev`:

      "skyverge/lumiere": "dev-docker-compose",
- `$ vendor/bin/lumiere up` and answer the configuration questions. Use the suggested values except for the questions mentioned below:
    - ? Where is your test instance of WordPress installed? (/var/www/wp): `/wordpress`
    - ? What is the password for your admin user? (admin) `password`
    - ? What is the host of the database you'll use for acceptance tests? (localhost) `mysql`
    - ? What is the host of the Selenium server you'll use for acceptance tests? (localhost) `chrome`
    - ? What is the host of the database you'll use for integration tests? (localhost) `mysql`
- Add a local `docker-compose.yml` file to map plugin's source code the appropriate directories inside the container

    ```yml
    version: '2'

    services:
      codeception:
        volumes:
          - $PWD:/project
          - $PWD:/wordpress/wp-content/plugins/$PLUGIN_DIR

      wordpress:
        volumes:
          - $PWD:/var/www/html/wp-content/plugins/$PLUGIN_DIR
    ```

   I didn't add the volume definition in the `docker-compose.yml` file included in the PR, because the volume configuration will be slightly different when we try to run the tests on CircleCI.

    I think we can either let Lumiere generate the configuration file and don't track it, or include `docker-compose.plugin.yml` and `docker-compose.circleci.yml` files in Lumiere and use them in combination with the base `docker-compose.yml` file where appropriate.

### Steps

We will use direct calls to `docker-compose` to create the containers and run the tests.

The first step is to create the containers for the Selenium server, MySQL, WordPress, and a Codeception:

`$ docker-compose -f vendor/skyverge/lumiere/docker/docker-compose.yml -f docker-compose.yml --env-file=.env.lumiere.dist --project-name=lumiere run --rm codeception bootstrap`

- [`-f`](https://docs.docker.com/compose/reference/overview/) defines the compose files to use (defaults to `docker-compose.yml` in the current directory). Paths in all included compose files are relative to the location of the first compose file.
- [`run --rm {service}`](https://docs.docker.com/compose/reference/run/) runs a one-time command against a service. In this case it runs a custom `bootstrap` command in the **codeception** service. The `--rm` part makes sure the container is destroyed when the command finishes.

    The `bootstrap` command in the line above creates the acceptance and integration databases, configures WordPress, installs and configure WooCommerce, generates the `dump.sql` file for Codeception, among other initial setup tasks.
- `--project-name=lumiere` is included to define the base name for the service instances and allow the same services to be used to run tests for different plugins.

    However, due to the different configurations that each plugin requires, I've often needed to destroy the existing containers and call `bootstrap` again when I switch from one plugin to another.

    I'm not sure if we'll end up removing the `--project-name` option or adding a `reset` command to the **codeception** service to refresh the WordPress installation before running tests for another plugin.

To run each of the test suites we will run standard Codeception commands inside the **codeception** container:

- `$ docker-compose -f vendor/skyverge/lumiere/docker/docker-compose.yml -f docker-compose.yml --env-file=.env.lumiere.dist --project-name=lumiere run --rm codeception vendor/bin/codecept run admin`
- `$ docker-compose -f vendor/skyverge/lumiere/docker/docker-compose.yml -f docker-compose.yml --env-file=.env.lumiere.dist --project-name=lumiere run --rm codeception vendor/bin/codecept run frontend`
- `$ docker-compose -f vendor/skyverge/lumiere/docker/docker-compose.yml -f docker-compose.yml --env-file=.env.lumiere.dist --project-name=lumiere run --rm codeception vendor/bin/codecept run integration`
- `$ docker-compose -f vendor/skyverge/lumiere/docker/docker-compose.yml -f docker-compose.yml --env-file=.env.lumiere.dist --project-name=lumiere run --rm codeception vendor/bin/codecept run unit`

**NOTE:** The `Symlinker` extension is not needed with this environment. It also doesn't work on the current configuration because WordPress runs on a different container and is unable to follow the symlink.